### PR TITLE
Bug 1597904 - Create the main background script.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,10 +4,304 @@
 
 "use strict";
 
+/* global QueryScorer */
+
+// The possible study branches.
 const BRANCHES = {
   CONTROL: "control",
   TREATMENT: "treatment",
 };
+
+// The possible tips to show.
+const TIPS = {
+  NONE: "",
+  CLEAR: "clear",
+  REFRESH: "refresh",
+
+  // There's an update and it's been downloaded and applied.  The user needs to
+  // restart to finish.
+  UPDATE_RESTART: "update_restart",
+
+  // The user should download the latest version from the web.
+  UPDATE_WEB: "update_web",
+};
+
+// Keywords for each tip type.
+const KEYWORDS = {
+  update: [
+    "2019",
+    "browser",
+    "download",
+    "fire",
+    "firefox",
+    "fox",
+    "free",
+    "get",
+    "install",
+    "installer",
+    "latest",
+    "mac",
+    "mozilla",
+    "new",
+    "newest",
+    "quantum",
+    "update",
+    "updates",
+    "version",
+    "windows",
+    "www.firefox.com",
+  ],
+  clear: [
+    "cache",
+    "clear",
+    "cookie",
+    "cookies",
+    "delete",
+    "firefox",
+    "history",
+    "load",
+    "loading",
+    "loads",
+    "location",
+    "page",
+  ],
+  refresh: [
+    "crash",
+    "crashes",
+    "crashing",
+    "firefox",
+    "keep",
+    "keeps",
+    "not",
+    "refresh",
+    "reset",
+    "respond",
+    "responding",
+    "responds",
+    "slow",
+    "slows",
+    "work",
+    "working",
+    "works",
+  ],
+};
+
+// Our browser.urlbar provider name.
+const URLBAR_PROVIDER_NAME = "interventions";
+
+// Telemetry names.
+const TELEMETRY_ROOT = "urlbarInterventionsExperiment";
+const TELEMETRY_SHOWN_PART = "tipShownCount";
+const TELEMETRY_SHOWN = `${TELEMETRY_ROOT}.${TELEMETRY_SHOWN_PART}`;
+const TELEMETRY_PICKED_PART = "tipPickedCount";
+const TELEMETRY_PICKED = `${TELEMETRY_ROOT}.${TELEMETRY_PICKED_PART}`;
+
+// The current study branch.
+let studyBranch;
+
+// The tip we should currently show.
+let currentTip = TIPS.NONE;
+
+// Object used to match the user's queries to tips.
+let queryScorer = new QueryScorer();
+
+// Tips shown in the current engagement (TIPS values).
+let tipsShownInCurrentEngagement = new Set();
+
+/**
+ * browser.urlbar.onBehaviorRequested listener.
+ */
+async function onBehaviorRequested(query) {
+  currentTip = TIPS.NONE;
+
+  if (!query.searchString) {
+    return "inactive";
+  }
+
+  // Get the scores and the top score.
+  let docScores = queryScorer.score(query.searchString);
+  let topDocScore = docScores[0];
+  console.debug(docScores);
+
+  // Multiple docs may have the top score, so collect them all.
+  let topDocIDs = new Set();
+  if (topDocScore.score != Infinity) {
+    for (let { score, document } of docScores) {
+      if (score != topDocScore.score) {
+        break;
+      }
+      topDocIDs.add(document.id);
+    }
+  }
+
+  // Determine the tip to show, if any.  If there are multiple top-score docs,
+  // prefer them in the following order.
+  if (topDocIDs.has("update")) {
+    if (await browser.experiments.urlbar.isBrowserUpdateReadyToInstall()) {
+      // Prompt the user to restart.
+      currentTip = TIPS.UPDATE_RESTART;
+    } else {
+      // Ask the user to download the latest version from the web.
+      currentTip = TIPS.UPDATE_WEB;
+    }
+  } else if (topDocIDs.has("clear")) {
+    currentTip = TIPS.CLEAR;
+  } else if (topDocIDs.has("refresh")) {
+    currentTip = TIPS.REFRESH;
+  } else {
+    // No tip.
+    return "inactive";
+  }
+
+  tipsShownInCurrentEngagement.add(currentTip);
+
+  return studyBranch == BRANCHES.TREATMENT ? "active" : "inactive";
+}
+
+/**
+ * browser.urlbar.onResultsRequested listener.
+ */
+async function onResultsRequested(query) {
+  let result = {
+    type: "tip",
+    source: "local",
+    suggestedIndex: 1,
+    payload: {
+      type: currentTip,
+    },
+  };
+
+  switch (currentTip) {
+    case TIPS.CLEAR:
+      result.payload.text = "Clear Firefox’s cache, cookies, history and more.";
+      result.payload.buttonText = "Choose What to Clear…";
+      result.payload.helpUrl =
+        "https://support.mozilla.org/kb/delete-browsing-search-download-history-firefox";
+      break;
+    case TIPS.REFRESH:
+      result.payload.text =
+        "Restore default settings and remove old add-ons for optimal performance.";
+      result.payload.buttonText = "Refresh Firefox…";
+      result.payload.helpUrl =
+        "https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings";
+      break;
+    case TIPS.UPDATE_RESTART:
+      result.payload.text =
+        "The latest Firefox is downloaded and ready to install.";
+      result.payload.buttonText = "Restart to Update";
+      result.payload.helpUrl =
+        "https://support.mozilla.org/kb/update-firefox-latest-release";
+      break;
+    case TIPS.UPDATE_WEB:
+      result.payload.text = "Get the latest Firefox browser.";
+      result.payload.buttonText = "Download Now";
+      result.payload.helpUrl =
+        "https://support.mozilla.org/kb/update-firefox-latest-release";
+      break;
+  }
+
+  return [result];
+}
+
+/**
+ * browser.urlbar.onResultPicked listener.  Called when a tip button is picked.
+ */
+async function onResultPicked(payload) {
+  // Update picked-count telemetry.
+  browser.telemetry.keyedScalarAdd(TELEMETRY_PICKED, payload.type, 1);
+
+  switch (payload.type) {
+    case TIPS.CLEAR:
+      browser.experiments.urlbar.openClearHistoryDialog();
+      break;
+    case TIPS.REFRESH:
+      browser.experiments.urlbar.resetBrowser();
+      break;
+    case TIPS.UPDATE_RESTART:
+      browser.experiments.urlbar.restartBrowser();
+      break;
+    case TIPS.UPDATE_WEB:
+      browser.tabs.create({ url: "https://www.mozilla.org/firefox/new/" });
+      break;
+  }
+}
+
+/**
+ * browser.urlbar.onEngagement listener.  Called when an engagement starts and
+ * stops.
+ */
+async function onEngagement(state) {
+  if (["engagement", "abandonment"].includes(state)) {
+    for (let tip of tipsShownInCurrentEngagement) {
+      browser.telemetry.keyedScalarAdd(TELEMETRY_SHOWN, tip, 1);
+    }
+  }
+  tipsShownInCurrentEngagement.clear();
+}
+
+/**
+ * Resets all the state we set on enrollment in the study.
+ */
+async function unenroll() {
+  await browser.experiments.urlbar.engagementTelemetry.clear({});
+  await browser.urlbar.onBehaviorRequested.removeListener(onBehaviorRequested);
+  await browser.urlbar.onResultsRequested.removeListener(onResultsRequested);
+  await browser.urlbar.onResultPicked.removeListener(onResultPicked);
+  await browser.urlbar.onEngagement.removeListener(onEngagement);
+  sendTestMessage("unenrolled");
+}
+
+/**
+ * Sets up all appropriate state for enrollment in the study.
+ */
+async function enroll() {
+  await browser.normandyAddonStudy.onUnenroll.addListener(async () => {
+    await unenroll();
+  });
+
+  // Add urlbar listeners.
+  await browser.urlbar.onBehaviorRequested.addListener(
+    onBehaviorRequested,
+    URLBAR_PROVIDER_NAME
+  );
+  await browser.urlbar.onResultsRequested.addListener(
+    onResultsRequested,
+    URLBAR_PROVIDER_NAME
+  );
+  await browser.urlbar.onResultPicked.addListener(
+    onResultPicked,
+    URLBAR_PROVIDER_NAME
+  );
+  await browser.urlbar.onEngagement.addListener(
+    onEngagement,
+    URLBAR_PROVIDER_NAME
+  );
+
+  // Enable urlbar engagement event telemetry.
+  await browser.experiments.urlbar.engagementTelemetry.set({ value: true });
+
+  // Register scalar telemetry.  We increment keyed scalars when we show a tip
+  // and when the user picks a tip.
+  await browser.telemetry.registerScalars(TELEMETRY_ROOT, {
+    [TELEMETRY_SHOWN_PART]: {
+      kind: "count",
+      keyed: true,
+      record_on_release: true,
+    },
+    [TELEMETRY_PICKED_PART]: {
+      kind: "count",
+      keyed: true,
+      record_on_release: true,
+    },
+  });
+
+  // Initialize the query scorer.
+  for (let docID in KEYWORDS) {
+    queryScorer.addDocument({ id: docID, words: KEYWORDS[docID] });
+  }
+
+  sendTestMessage("enrolled");
+}
 
 /**
  * Logs a debug message, which the test harness interprets as a message the
@@ -18,41 +312,6 @@ const BRANCHES = {
  */
 function sendTestMessage(msg) {
   console.debug(browser.runtime.id, msg);
-}
-
-/**
- * Resets all the state we set on enrollment in the study.
- *
- * @param {bool} isTreatmentBranch
- *   True if we were enrolled on the treatment branch, false if control.
- */
-async function unenroll(isTreatmentBranch) {
-  //XXX Handle unenrollment here.
-
-  sendTestMessage("unenrolled");
-}
-
-/**
- * Sets up all appropriate state for enrollment in the study.
- *
- * @param {bool} isTreatmentBranch
- *   True if we are enrolling on the treatment branch, false if control.
- */
-async function enroll(isTreatmentBranch) {
-  await browser.normandyAddonStudy.onUnenroll.addListener(async () => {
-    await unenroll(isTreatmentBranch);
-  });
-
-  // Enable urlbar engagement event telemetry.
-  await browser.urlbar.engagementTelemetry.set({ value: true });
-
-  //XXX Handle enrollment here.
-
-  if (isTreatmentBranch) {
-    //XXX Handle enrollment in the treatment branch here.
-  }
-
-  sendTestMessage("enrolled");
 }
 
 (async function main() {
@@ -71,7 +330,8 @@ async function enroll(isTreatmentBranch) {
   if (study) {
     // Sanity check the study.  This conditional should always be true.
     if (study.active && Object.values(BRANCHES).includes(study.branch)) {
-      await enroll(study.branch == BRANCHES.TREATMENT);
+      studyBranch = study.branch;
+      await enroll();
     }
     sendTestMessage("ready");
     return;
@@ -82,7 +342,8 @@ async function enroll(isTreatmentBranch) {
   installPromise.then(async isTemporaryInstall => {
     if (isTemporaryInstall) {
       console.debug("isTemporaryInstall");
-      await enroll(true);
+      studyBranch = BRANCHES.TREATMENT;
+      await enroll();
     }
     sendTestMessage("ready");
   });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,7 @@
   },
   "permissions": [
     "normandyAddonStudy",
+    "telemetry",
     "urlbar"
   ],
   "background": {
@@ -26,5 +27,15 @@
     ]
   },
   "incognito": "spanning",
-  "hidden": true
+  "hidden": true,
+  "experiment_apis": {
+    "experiments_urlbar": {
+      "schema": "experiments/urlbar/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["experiments", "urlbar"]],
+        "script": "experiments/urlbar/api.js"
+      }
+    }
+  }
 }

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -6,5 +6,17 @@
 support-files =
   head.js
   ../urlbar_interventions-1.0.0.zip
+  ../../../../toolkit/mozapps/update/tests/data/shared.js
+  ../../../../toolkit/mozapps/update/tests/data/sharedUpdateXML.js
+  ../../../../toolkit/mozapps/update/tests/browser/app_update.sjs
+  ../../../../toolkit/mozapps/update/tests/browser/downloadPage.html
+  ../../../../toolkit/mozapps/update/tests/browser/testConstants.js
 
 [browser_QueryScorer.js]
+
+[browser_test.js]
+
+[browser_updateRestart_control.js]
+[browser_updateRestart_treatment.js]
+[browser_updateWeb_control.js]
+[browser_updateWeb_treatment.js]

--- a/tests/tests/browser/browser_updateRestart_control.js
+++ b/tests/tests/browser/browser_updateRestart_control.js
@@ -1,0 +1,46 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Checks the UPDATE_RESTART tip on the control branch.
+//
+// The update parts of this test are adapted from:
+// https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/tests/browser/browser_aboutDialog_bc_downloaded_staged.js
+
+"use strict";
+
+let params = {
+  queryString: "&invalidCompleteSize=1",
+  backgroundUpdate: true,
+  continueFile: CONTINUE_STAGING,
+  waitForUpdateState: STATE_APPLIED,
+};
+
+let preSteps = [
+  {
+    panelId: "apply",
+    checkActiveUpdate: { state: STATE_APPLIED },
+    continueFile: null,
+  },
+];
+
+add_task(async function test() {
+  await initAddonTest(ADDON_PATH, EXPECTED_ADDON_SIGNED_STATE);
+
+  // Enable the pref that automatically downloads and installs updates.
+  await SpecialPowers.pushPrefEnv({
+    set: [[PREF_APP_UPDATE_STAGING_ENABLED, true]],
+  });
+
+  await withStudy({ branch: BRANCHES.CONTROL }, async () => {
+    await initUpdate(params);
+    await withAddon(async () => {
+      // Set up the "apply" update state.
+      await processUpdateSteps(preSteps);
+
+      await doControlTest({
+        searchString: "update",
+        tip: TIPS.UPDATE_RESTART,
+      });
+    });
+  });
+});

--- a/tests/tests/browser/browser_updateRestart_treatment.js
+++ b/tests/tests/browser/browser_updateRestart_treatment.js
@@ -1,0 +1,61 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Checks the UPDATE_RESTART tip on the treatment branch.
+//
+// The update parts of this test are adapted from:
+// https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/tests/browser/browser_aboutDialog_bc_downloaded_staged.js
+
+"use strict";
+
+let params = {
+  queryString: "&invalidCompleteSize=1",
+  backgroundUpdate: true,
+  continueFile: CONTINUE_STAGING,
+  waitForUpdateState: STATE_APPLIED,
+};
+
+let preSteps = [
+  {
+    panelId: "apply",
+    checkActiveUpdate: { state: STATE_APPLIED },
+    continueFile: null,
+  },
+];
+
+add_task(async function test() {
+  await initAddonTest(ADDON_PATH, EXPECTED_ADDON_SIGNED_STATE);
+
+  // Enable the pref that automatically downloads and installs updates.
+  await SpecialPowers.pushPrefEnv({
+    set: [[PREF_APP_UPDATE_STAGING_ENABLED, true]],
+  });
+
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await initUpdate(params);
+    await withAddon(async () => {
+      // Set up the "apply" update state.
+      await processUpdateSteps(preSteps);
+
+      // Picking the tip should attempt to restart the browser.
+      await doTreatmentTest({
+        searchString: "update",
+        tip: TIPS.UPDATE_RESTART,
+        title: "The latest Firefox is downloaded and ready to install.",
+        button: "Restart to Update",
+        awaitCallback() {
+          return TestUtils.topicObserved(
+            "quit-application-requested",
+            (cancelQuit, data) => {
+              if (data == "restart") {
+                cancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
+                return true;
+              }
+              return false;
+            }
+          );
+        },
+      });
+    });
+  });
+});

--- a/tests/tests/browser/browser_updateWeb_control.js
+++ b/tests/tests/browser/browser_updateWeb_control.js
@@ -1,0 +1,46 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Checks the UPDATE_WEB tip on the control branch.
+//
+// The update parts of this test are adapted from:
+// https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/tests/browser/browser_aboutDialog_fc_check_unsupported.js
+
+"use strict";
+
+let params = { queryString: "&unsupported=1" };
+
+let preSteps = [
+  {
+    panelId: "checkingForUpdates",
+    checkActiveUpdate: null,
+    continueFile: CONTINUE_CHECK,
+  },
+  {
+    panelId: "unsupportedSystem",
+    checkActiveUpdate: null,
+    continueFile: null,
+  },
+];
+
+add_task(async function test() {
+  await initAddonTest(ADDON_PATH, EXPECTED_ADDON_SIGNED_STATE);
+  await withStudy({ branch: BRANCHES.CONTROL }, async () => {
+    await initUpdate(params);
+    await withAddon(async () => {
+      // Force a check to get the ball running.
+      let checker = Cc["@mozilla.org/updates/update-checker;1"].getService(
+        Ci.nsIUpdateChecker
+      );
+      checker.checkForUpdates({}, true);
+
+      // Set up the "unsupported update" update state.
+      await processUpdateSteps(preSteps);
+
+      await doControlTest({
+        searchString: "update",
+        tip: TIPS.UPDATE_WEB,
+      });
+    });
+  });
+});

--- a/tests/tests/browser/browser_updateWeb_treatment.js
+++ b/tests/tests/browser/browser_updateWeb_treatment.js
@@ -1,0 +1,58 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Checks the UPDATE_WEB tip on the treatment branch.
+//
+// The update parts of this test are adapted from:
+// https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/tests/browser/browser_aboutDialog_fc_check_unsupported.js
+
+"use strict";
+
+let params = { queryString: "&unsupported=1" };
+
+let preSteps = [
+  {
+    panelId: "checkingForUpdates",
+    checkActiveUpdate: null,
+    continueFile: CONTINUE_CHECK,
+  },
+  {
+    panelId: "unsupportedSystem",
+    checkActiveUpdate: null,
+    continueFile: null,
+  },
+];
+
+add_task(async function test() {
+  await initAddonTest(ADDON_PATH, EXPECTED_ADDON_SIGNED_STATE);
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await initUpdate(params);
+    await withAddon(async () => {
+      // Force a check to get the ball running.
+      let checker = Cc["@mozilla.org/updates/update-checker;1"].getService(
+        Ci.nsIUpdateChecker
+      );
+      checker.checkForUpdates({}, true);
+
+      // Set up the "unsupported update" update state.
+      await processUpdateSteps(preSteps);
+
+      // Picking the tip should open the download page in a new tab.
+      let downloadTab = await doTreatmentTest({
+        searchString: "update",
+        tip: TIPS.UPDATE_WEB,
+        title: "Get the latest Firefox browser.",
+        button: "Download Now",
+        awaitCallback() {
+          return BrowserTestUtils.waitForNewTab(
+            gBrowser,
+            "https://www.mozilla.org/firefox/new/"
+          );
+        },
+      });
+
+      Assert.equal(gBrowser.selectedTab, downloadTab);
+      BrowserTestUtils.removeTab(downloadTab);
+    });
+  });
+});

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -13,7 +13,10 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   AddonStudies: "resource://normandy/lib/AddonStudies.jsm",
   AddonTestUtils: "resource://testing-common/AddonTestUtils.jsm",
   NormandyTestUtils: "resource://testing-common/NormandyTestUtils.jsm",
+  ResetProfile: "resource://gre/modules/ResetProfile.jsm",
   TelemetryTestUtils: "resource://testing-common/TelemetryTestUtils.jsm",
+  UpdateUtils: "resource://gre/modules/UpdateUtils.jsm",
+  UrlbarTestUtils: "resource://testing-common/UrlbarTestUtils.jsm",
 });
 
 // The path of the add-on file relative to `getTestFilePath`.
@@ -23,6 +26,62 @@ const ADDON_PATH = "urlbar_interventions-1.0.0.zip";
 // the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.
 const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_MISSING;
 // const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_PRIVILEGED;
+
+const BRANCHES = {
+  CONTROL: "control",
+  TREATMENT: "treatment",
+};
+
+const TIPS = {
+  NONE: "",
+  CLEAR: "clear",
+  REFRESH: "refresh",
+  UPDATE_RESTART: "update_restart",
+  UPDATE_ASK: "update_ask",
+  UPDATE_REFRESH: "update_refresh",
+  UPDATE_WEB: "update_web",
+};
+
+const TELEMETRY_ROOT = "urlbarInterventionsExperiment";
+const TELEMETRY_SHOWN_PART = "tipShownCount";
+const TELEMETRY_SHOWN = `${TELEMETRY_ROOT}.${TELEMETRY_SHOWN_PART}`;
+const TELEMETRY_PICKED_PART = "tipPickedCount";
+const TELEMETRY_PICKED = `${TELEMETRY_ROOT}.${TELEMETRY_PICKED_PART}`;
+
+// For our app-update tests, we use helpers from the About window app-update
+// tests.
+//
+// These globals are all in toolkit/mozapps/update/tests/browser/head.js, but we
+// declare them individually instead of using `import-globals-from` because `npx
+// eslint` from the repo directory wouldn't be able to find them.
+/*
+  global
+  CONTINUE_CHECK,
+  CONTINUE_DOWNLOAD,
+  CONTINUE_STAGING,
+  continueFileHandler,
+  gAUS,
+  gDetailsURL,
+  gEnv,
+  gUpdateManager,
+  getPatchOfType,
+  getVersionParams,
+  logTestInfo,
+  PREF_APP_UPDATE_BITS_ENABLED,
+  PREF_APP_UPDATE_DISABLEDFORTESTING,
+  PREF_APP_UPDATE_STAGING_ENABLED,
+  PREF_APP_UPDATE_URL_MANUAL,
+  setUpdateURL,
+  setupTestUpdater,
+  STATE_APPLIED,
+  STATE_DOWNLOADING,
+  STATE_PENDING,
+  URL_HTTP_UPDATE_SJS
+*/
+Services.scriptloader.loadSubScript(
+  "chrome://mochitests/content/browser/toolkit/mozapps/update/tests/browser/head.js",
+  this
+);
 
 AddonTestUtils.initMochitest(this);
 
@@ -196,6 +255,12 @@ async function withStudy(studyPartial, callback) {
  *   of AddonWrapper (defined in XPIDatabase.jsm).
  */
 async function withAddon(callback) {
+  let addon = await installAddon();
+  await callback(addon);
+  await uninstallAddon(addon);
+}
+
+async function installAddon() {
   // If the add-on isn't signed, then as a convenience during development,
   // install it as a temporary add-on so that it can use privileged APIs.  If it
   // is signed, install it normally.
@@ -214,8 +279,10 @@ async function withAddon(callback) {
     "The add-on should have the expected signed state"
   );
 
-  await callback(addon);
+  return addon;
+}
 
+async function uninstallAddon(addon) {
   // If `withStudy` was called and there's an active study, Normandy will
   // automatically end the study when it sees that the add-on has been
   // uninstalled.  That's fine, but that automatic unenrollment will race the
@@ -231,4 +298,299 @@ async function withAddon(callback) {
       : Promise.resolve(),
     addon.uninstall(),
   ]);
+}
+
+/**
+ * Checks a tip on the treatment branch: Starts a search that should trigger a
+ * tip, picks the tip, waits for the tip's action to happen, and checks scalar
+ * telemetry (the telemetry recorded by the extension).
+ *
+ * @param {string} searchString
+ *   The search string.
+ * @param {TIPS.*} tip
+ *   The expected tip type.
+ * @param {string} title
+ *   The expected tip title.
+ * @param {string} button
+ *   The expected button title.
+ * @param {function} awaitCallback
+ *   A function that checks the tip's action.  Should return a promise (or be
+ *   async).
+ * @return {*}
+ *   The value returned from `awaitCallback`.
+ */
+async function doTreatmentTest({
+  searchString,
+  tip,
+  title,
+  button,
+  awaitCallback,
+} = {}) {
+  // Do a search that triggers the tip.
+  let [result, element] = await awaitTip(searchString);
+  Assert.strictEqual(result.payload.type, tip);
+  Assert.equal(element._elements.get("title").textContent, title);
+  Assert.equal(element._elements.get("tipButton").textContent, button);
+  Assert.ok(BrowserTestUtils.is_visible(element._elements.get("helpButton")));
+
+  // Pick the tip, which should open the refresh dialog.  Click its cancel
+  // button.
+  let values = await Promise.all([awaitCallback(), pickTip()]);
+  Assert.ok(true, "Refresh dialog opened");
+
+  // Shown- and picked-count telemetry should be updated.
+  let scalars = TelemetryTestUtils.getProcessScalars("dynamic", true, true);
+  for (let name of [TELEMETRY_SHOWN, TELEMETRY_PICKED]) {
+    TelemetryTestUtils.assertKeyedScalar(scalars, name, tip, 1);
+  }
+
+  return values[0] || null;
+}
+
+/**
+ * Checks for the absence of a tip on the control branch: Starts a search that
+ * should trigger a tip on the treatment branch, makes sure no tip appears, and
+ * checks scalar telemetry (the telemetry recorded by the extension).
+ *
+ * @param {string} searchString
+ *   The search string.
+ * @param {TIPS.*} tip
+ *   The expected tip type (which should not appear).
+ */
+async function doControlTest({ searchString, tip } = {}) {
+  // Do a search that would trigger the tip.
+  await awaitNoTip(searchString);
+
+  // Blur the urlbar so that the engagement is ended and telemetry is recorded.
+  await UrlbarTestUtils.promisePopupClose(window, () => gURLBar.blur());
+
+  // Shown-count telemetry should be updated, but not picked count.
+  await TestUtils.waitForCondition(() => {
+    return (
+      TELEMETRY_SHOWN in TelemetryTestUtils.getProcessScalars("dynamic", true)
+    );
+  }, "Wait for telemetry to be recorded");
+  let scalars = TelemetryTestUtils.getProcessScalars("dynamic", true, true);
+  TelemetryTestUtils.assertKeyedScalar(scalars, TELEMETRY_SHOWN, tip, 1);
+  Assert.ok(!(TELEMETRY_PICKED in scalars));
+}
+
+/**
+ * Initializes a mock app update.  This function and the other update-related
+ * functions are adapted from `runAboutDialogUpdateTest` here:
+ * https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/tests/browser/head.js
+ */
+async function initUpdate(params) {
+  gEnv.set("MOZ_TEST_SLOW_SKIP_UPDATE_STAGE", "1");
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      [PREF_APP_UPDATE_DISABLEDFORTESTING, false],
+      [PREF_APP_UPDATE_URL_MANUAL, gDetailsURL],
+    ],
+  });
+
+  await setupTestUpdater();
+
+  let queryString = params.queryString ? params.queryString : "";
+  let updateURL =
+    URL_HTTP_UPDATE_SJS +
+    "?detailsURL=" +
+    gDetailsURL +
+    queryString +
+    getVersionParams();
+  if (params.backgroundUpdate) {
+    setUpdateURL(updateURL);
+    gAUS.checkForBackgroundUpdates();
+    if (params.continueFile) {
+      await continueFileHandler(params.continueFile);
+    }
+    if (params.waitForUpdateState) {
+      await TestUtils.waitForCondition(
+        () =>
+          gUpdateManager.activeUpdate &&
+          gUpdateManager.activeUpdate.state == params.waitForUpdateState,
+        "Waiting for update state: " + params.waitForUpdateState,
+        undefined,
+        200
+      ).catch(e => {
+        // Instead of throwing let the check below fail the test so the panel
+        // ID and the expected panel ID is printed in the log.
+        logTestInfo(e);
+      });
+      // Display the UI after the update state equals the expected value.
+      Assert.equal(
+        gUpdateManager.activeUpdate.state,
+        params.waitForUpdateState,
+        "The update state value should equal " + params.waitForUpdateState
+      );
+    }
+  } else {
+    updateURL += "&slowUpdateCheck=1&useSlowDownloadMar=1";
+    setUpdateURL(updateURL);
+  }
+}
+
+/**
+ * Performs steps in a mock update.  This function and the other update-related
+ * functions are adapted from `runAboutDialogUpdateTest` here:
+ * https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/tests/browser/head.js
+ */
+async function processUpdateSteps(steps) {
+  for (let step of steps) {
+    await processUpdateStep(step);
+  }
+}
+
+/**
+ * Performs a step in a mock update.  This function and the other update-related
+ * functions are adapted from `runAboutDialogUpdateTest` here:
+ * https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/tests/browser/head.js
+ */
+async function processUpdateStep(step) {
+  if (typeof step == "function") {
+    step();
+    return;
+  }
+
+  const { panelId, checkActiveUpdate, continueFile, downloadInfo } = step;
+  if (checkActiveUpdate) {
+    await TestUtils.waitForCondition(
+      () => gUpdateManager.activeUpdate,
+      "Waiting for active update"
+    );
+    Assert.ok(
+      !!gUpdateManager.activeUpdate,
+      "There should be an active update"
+    );
+    Assert.equal(
+      gUpdateManager.activeUpdate.state,
+      checkActiveUpdate.state,
+      "The active update state should equal " + checkActiveUpdate.state
+    );
+  } else {
+    Assert.ok(
+      !gUpdateManager.activeUpdate,
+      "There should not be an active update"
+    );
+  }
+
+  if (panelId == "downloading") {
+    for (let i = 0; i < downloadInfo.length; ++i) {
+      let data = downloadInfo[i];
+      // The About Dialog tests always specify a continue file.
+      await continueFileHandler(continueFile);
+      let patch = getPatchOfType(data.patchType);
+      // The update is removed early when the last download fails so check
+      // that there is a patch before proceeding.
+      let isLastPatch = i == downloadInfo.length - 1;
+      if (!isLastPatch || patch) {
+        let resultName = data.bitsResult ? "bitsResult" : "internalResult";
+        patch.QueryInterface(Ci.nsIWritablePropertyBag);
+        await TestUtils.waitForCondition(
+          () => patch.getProperty(resultName) == data[resultName],
+          "Waiting for expected patch property " +
+            resultName +
+            " value: " +
+            data[resultName],
+          undefined,
+          200
+        ).catch(e => {
+          // Instead of throwing let the check below fail the test so the
+          // property value and the expected property value is printed in
+          // the log.
+          logTestInfo(e);
+        });
+        Assert.equal(
+          patch.getProperty(resultName),
+          data[resultName],
+          "The patch property " +
+            resultName +
+            " value should equal " +
+            data[resultName]
+        );
+      }
+    }
+  } else if (continueFile) {
+    await continueFileHandler(continueFile);
+  }
+}
+
+/**
+ * Starts a search and asserts that the second result is a tip.
+ *
+ * @param {string} searchString
+ *   The search string.
+ * @return {[result, element]}
+ *   The result and its element in the DOM.
+ */
+async function awaitTip(searchString) {
+  let context = await UrlbarTestUtils.promiseAutocompleteResultPopup({
+    window,
+    value: searchString,
+    waitForFocus,
+    fireInputEvent: true,
+  });
+  Assert.ok(context.results.length >= 2);
+  let result = context.results[1];
+  Assert.equal(result.type, UrlbarUtils.RESULT_TYPE.TIP);
+  let element = await UrlbarTestUtils.waitForAutocompleteResultAt(window, 1);
+  return [result, element];
+}
+
+/**
+ * Starts a search and asserts that there are no tips.
+ *
+ * @param {string} searchString
+ *   The search string.
+ */
+async function awaitNoTip(searchString) {
+  let context = await UrlbarTestUtils.promiseAutocompleteResultPopup({
+    window,
+    value: searchString,
+    waitForFocus,
+    fireInputEvent: true,
+  });
+  for (let result of context.results) {
+    Assert.notEqual(result.type, UrlbarUtils.RESULT_TYPE.TIP);
+  }
+}
+
+/**
+ * Picks the current tip's button.  The view should be open and the second
+ * result should be a tip.
+ */
+async function pickTip() {
+  let result = await UrlbarTestUtils.getDetailsOfResultAt(window, 1);
+  let button = result.element.row._elements.get("tipButton");
+  await UrlbarTestUtils.promisePopupClose(window, () => {
+    EventUtils.synthesizeMouseAtCenter(button, {});
+  });
+}
+
+/**
+ * Sets up the profile so that it can be reset.
+ */
+function makeProfileResettable() {
+  // Make reset possible.
+  let profileService = Cc["@mozilla.org/toolkit/profile-service;1"].getService(
+    Ci.nsIToolkitProfileService
+  );
+  let currentProfileDir = Services.dirsvc.get("ProfD", Ci.nsIFile);
+  let profileName = "mochitest-test-profile-temp-" + Date.now();
+  let tempProfile = profileService.createProfile(
+    currentProfileDir,
+    profileName
+  );
+  Assert.ok(
+    ResetProfile.resetSupported(),
+    "Should be able to reset from mochitest's temporary profile once it's in the profile manager."
+  );
+
+  registerCleanupFunction(() => {
+    tempProfile.remove(false);
+    Assert.ok(
+      !ResetProfile.resetSupported(),
+      "Shouldn't be able to reset from mochitest's temporary profile once removed from the profile manager."
+    );
+  });
 }

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -365,11 +365,11 @@ async function doControlTest({ searchString, tip } = {}) {
   await UrlbarTestUtils.promisePopupClose(window, () => gURLBar.blur());
 
   // Shown-count telemetry should be updated, but not picked count.
-  await TestUtils.waitForCondition(() => {
-    return (
-      TELEMETRY_SHOWN in TelemetryTestUtils.getProcessScalars("dynamic", true)
-    );
-  }, "Wait for telemetry to be recorded");
+  await TestUtils.waitForCondition(
+    () =>
+      TELEMETRY_SHOWN in TelemetryTestUtils.getProcessScalars("dynamic", true),
+    "Wait for telemetry to be recorded"
+  );
   let scalars = TelemetryTestUtils.getProcessScalars("dynamic", true, true);
   TelemetryTestUtils.assertKeyedScalar(scalars, TELEMETRY_SHOWN, tip, 1);
   Assert.ok(!(TELEMETRY_PICKED in scalars));


### PR DESCRIPTION
I was waiting for bug 1599360 and bug 1596258 to be resolved
first before asking for review. My wip branch is based on those
bugs. But we can start review on most of the background script
and some of the tests without them. Those bugs make the
additional `UPDATE_ASK` and `UPDATE_REFRESH` tips possible, plus
an update check from within the extension. I'll file follow-up
bugs for those additional tips once this is reviewed and merged,
and depending on the outcomes of the two bugs.

The tests are based on the update tests in
toolkit/mozapps/update/tests/browser and use the same helpers.
The non-update tips are tested in browser_test.js, and the update
tips are tested in individual browser_update* files.