### PR TITLE
Bug 1604387 - Improve QueryScorer.

### DIFF
--- a/src/QueryScorer.js
+++ b/src/QueryScorer.js
@@ -7,33 +7,44 @@
 /**
  * This class scores a query string against sets of keywords.  To refer to a
  * single set of keywords, we borrow the term "document" from search engine
- * terminology.  To use this class, first add your documents with `addDocument`,
+ * terminology, and to refer to all documents, we borrow the term "corpus".  To
+ * use this class, first add the documents in your corpus using `addDocument`,
  * and then call `score` with a query string.  `score` returns a sorted array of
  * document-score pairs.
  *
  * The scoring method is simple and is based on Levenshtein edit distance.
- * Therefore, lower scores indicate a better match than higher scores.  In
- * summary, we compute the edit distances between the query words and the words
- * in each document that best match them.  If any of these distances is larger
- * than some threshold -- defined by `distanceThreshold` -- then the document
- * does not match the query, and we assign it a score of Infinity.  The score
- * for a document is the sum of these distances.
- *
- * For example, if the query is a single word, then the distance between it and
- * a given document is the minimum distance between it and all words in the
- * document.  If the document contains the word exactly, then the distance is
- * zero.  If the query is two words, then the distance between it and the
- * document is the sum of the minimum distances between each query word and all
- * words in the document.  For details, see `score`.
+ * Therefore, lower scores indicate a better match than higher scores.  We first
+ * split the query string into words.  For the first word, we compute the edit
+ * distances between it and each word in the corpus.  For each subsequent word,
+ * we compute the edit distances between it and each possible prefix of each
+ * word in the corpus.  As we compute these distances for each word in the query
+ * string, we keep a running sum per document of the minimum (best matching)
+ * edit distances.  This sum a document's final score.  This class is designed
+ * to score query strings as the user types them, which is why we match on
+ * corpus prefixes for words in the query string after the first.
  *
  * As mentioned, `score` returns a sorted array of document-score pairs.  It's
  * up to you to filter the array to exclude scores above a certain threshold, or
  * to take the top scorer, etc.
  */
 class QueryScorer {
-  constructor(distanceThreshold = 1) {
-    this._distanceThreshold = distanceThreshold;
+  /**
+   * @param {number} distanceThreshold
+   *   When we compute the edit distances between a word in the query string and
+   *   each word or prefix of a document, edit distances larger than this number
+   *   force the score for that document to be Infinity -- i.e., no match.
+   * @param {array} stopWords
+   *   These words are ignored when they appear in the query string.  Similar to
+   *   the prefix matching described above, we ignore the stop words exactly
+   *   when they appear as the first word in a query.  For subsequent words in
+   *   the query, we ignore all possible prefixes of the stop words.
+   */
+  constructor({ distanceThreshold = 1, stopWords = [] } = {}) {
+    this.distanceThreshold = distanceThreshold;
+    this.stopWords = stopWords;
+    this._documents = new Set();
     this._documentsByWord = new Map();
+    this._documentsByPrefix = new Map();
   }
 
   get distanceThreshold() {
@@ -41,7 +52,27 @@ class QueryScorer {
   }
 
   set distanceThreshold(value) {
-    this._distanceThreshold = value;
+    return (this._distanceThreshold = value);
+  }
+
+  get stopWords() {
+    return this._stopWords;
+  }
+
+  set stopWords(array) {
+    // _stopWords contains the stop words exactly.
+    this._stopWords = new Set(array.map(word => word.toLocaleLowerCase()));
+
+    // _stopWordPrefixes contains all possible prefixes of each stop word, up to
+    // and including the whole word.
+    this._stopWordPrefixes = new Set();
+    for (let word of this._stopWords) {
+      for (let i = 1; i <= word.length; i++) {
+        this._stopWordPrefixes.add(word.substring(0, i));
+      }
+    }
+
+    return this._stopWords;
   }
 
   /**
@@ -55,11 +86,23 @@ class QueryScorer {
    *   The set of words in the document.
    */
   addDocument(doc) {
+    this._documents.add(doc);
+
     doc.words = doc.words.map(word => word.toLocaleLowerCase());
     for (let word of doc.words) {
+      // Update _documentsByWord, whose keys are the document's words exactly.
       let docs = this._documentsByWord.get(word) || new Set();
       docs.add(doc);
       this._documentsByWord.set(word, docs);
+
+      // Update _documentsByPrefix, whose keys are all possible prefixes of the
+      // document's words, up to and including the whole words.
+      for (let i = 1; i <= word.length; i++) {
+        let prefix = word.substring(0, i);
+        let docs = this._documentsByPrefix.get(prefix) || new Set();
+        docs.add(doc);
+        this._documentsByPrefix.set(prefix, docs);
+      }
     }
   }
 
@@ -88,9 +131,17 @@ class QueryScorer {
       .split(/\s+/)
       .map(word => word.toLocaleLowerCase());
     let sumByDoc = new Map();
-    for (let searchWord of searchWords) {
+    for (let i = 0; i < searchWords.length; i++) {
+      let searchWord = searchWords[i];
+      if (
+        (i == 0 && this.stopWords.has(searchWord)) ||
+        (i > 0 && this._stopWordPrefixes.has(searchWord))
+      ) {
+        continue;
+      }
       let minDistanceByDoc = new Map();
-      for (let [docWord, docs] of this._documentsByWord) {
+      let map = i == 0 ? this._documentsByWord : this._documentsByPrefix;
+      for (let [docWord, docs] of map) {
         let distance = this._levenshtein(searchWord, docWord);
         if (distance > this.distanceThreshold) {
           distance = Infinity;
@@ -110,8 +161,12 @@ class QueryScorer {
       }
     }
     let results = [];
-    for (let [doc, sum] of sumByDoc) {
-      results.push({ document: doc, score: sum });
+    for (let doc of this._documents) {
+      let sum = sumByDoc.get(doc);
+      results.push({
+        document: doc,
+        score: sum === undefined ? Infinity : sum,
+      });
     }
     results.sort((a, b) => a.score - b.score);
     return results;

--- a/src/background.js
+++ b/src/background.js
@@ -41,16 +41,12 @@ const KEYWORDS = {
     "2019",
     "browser",
     "download",
-    "fire",
-    "firefox",
-    "fox",
     "free",
     "get",
     "install",
     "installer",
     "latest",
     "mac",
-    "mozilla",
     "new",
     "newest",
     "quantum",
@@ -66,7 +62,6 @@ const KEYWORDS = {
     "cookie",
     "cookies",
     "delete",
-    "firefox",
     "history",
     "load",
     "loading",
@@ -78,7 +73,6 @@ const KEYWORDS = {
     "crash",
     "crashes",
     "crashing",
-    "firefox",
     "keep",
     "keeps",
     "not",
@@ -94,6 +88,10 @@ const KEYWORDS = {
     "works",
   ],
 };
+
+// Words that are ignored in query strings.  Put another way, the user can type
+// these and not affect query matching one way or the other.
+const STOP_WORDS = ["firefox", "mozilla"];
 
 // Our browser.urlbar provider name.
 const URLBAR_PROVIDER_NAME = "interventions";
@@ -115,7 +113,7 @@ let studyBranch;
 let currentTip = TIPS.NONE;
 
 // Object used to match the user's queries to tips.
-let queryScorer = new QueryScorer();
+let queryScorer = new QueryScorer({ stopWords: STOP_WORDS });
 
 // Tips shown in the current engagement (TIPS values).
 let tipsShownInCurrentEngagement = new Set();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Urlbar Interventions",
-  "version": "1.0a2",
+  "version": "1.0a3",
   "description": "Shows relevant tips in the urlbar view when you type certain search terms.",
   "applications": {
     "gecko": {

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -5,7 +5,7 @@
 [DEFAULT]
 support-files =
   head.js
-  ../urlbar_interventions-1.0a1.zip
+  ../urlbar_interventions-1.0a3.zip
   ../../../../toolkit/mozapps/update/tests/data/shared.js
   ../../../../toolkit/mozapps/update/tests/data/sharedUpdateXML.js
   ../../../../toolkit/mozapps/update/tests/browser/app_update.sjs

--- a/tests/tests/browser/browser_QueryScorer.js
+++ b/tests/tests/browser/browser_QueryScorer.js
@@ -5,7 +5,8 @@
 
 "use strict";
 
-const CUTOFF_SCORE = 1;
+const DISTANCE_THRESHOLD = 1;
+const STOP_WORDS = ["stop"];
 
 let documents = {
   fruits: "apple pear banana orange pomegranate",
@@ -40,10 +41,30 @@ let tests = [
   },
   {
     query: "banana app",
-    matches: [],
+    matches: ["fruits"],
   },
   {
     query: "banana ap",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana a",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana aple",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana apl",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana al",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana all",
     matches: [],
   },
 
@@ -73,10 +94,18 @@ let tests = [
   },
   {
     query: "vanilla butterscot",
-    matches: [],
+    matches: ["iceCreams"],
   },
   {
     query: "vanilla buttersco",
+    matches: ["iceCreams"],
+  },
+  {
+    query: "vanilla butersco",
+    matches: ["iceCreams"],
+  },
+  {
+    query: "vanilla buersco",
     matches: [],
   },
 
@@ -106,16 +135,65 @@ let tests = [
   },
   {
     query: "aardvark hamst",
-    matches: [],
+    matches: ["animals"],
   },
   {
     query: "aardvark hams",
+    matches: ["animals"],
+  },
+  {
+    query: "aardvark has",
+    matches: ["animals"],
+  },
+  {
+    query: "aardvark hass",
+    matches: ["animals"],
+  },
+  {
+    query: "aardvark hasss",
     matches: [],
   },
 
   {
     query: "banana aardvark",
     matches: [],
+  },
+
+  {
+    query: "banana stop",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana sto",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana st",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana s",
+    matches: ["fruits"],
+  },
+  {
+    query: "banana stop apple",
+    matches: ["fruits"],
+  },
+  {
+    query: "stop b",
+    matches: ["fruits", "iceCreams", "animals"],
+  },
+  {
+    query: "stop ban",
+    matches: ["fruits", "iceCreams", "animals"],
+  },
+  {
+    query: "stop bana",
+    matches: ["fruits"],
+  },
+  {
+    query: "stop banana",
+    matches: ["fruits"],
   },
 ];
 
@@ -128,7 +206,10 @@ add_task(async function test() {
     let fileURI = addon.getResourceURI("QueryScorer.js");
     Services.scriptloader.loadSubScript(fileURI.spec);
 
-    let qs = new QueryScorer();
+    let qs = new QueryScorer({
+      distanceThreshold: DISTANCE_THRESHOLD,
+      stopWords: STOP_WORDS,
+    });
 
     for (let [id, words] of Object.entries(documents)) {
       qs.addDocument({ id, words: words.split(/\s+/) });
@@ -138,7 +219,7 @@ add_task(async function test() {
       info(`Checking query: ${query}`);
       let actual = qs
         .score(query)
-        .filter(result => result.score <= CUTOFF_SCORE)
+        .filter(result => result.score <= DISTANCE_THRESHOLD)
         .map(result => result.document.id);
       Assert.deepEqual(actual, matches);
     }

--- a/tests/tests/browser/browser_test.js
+++ b/tests/tests/browser/browser_test.js
@@ -21,10 +21,10 @@ add_task(async function refresh_treatment() {
           "Restore default settings and remove old add-ons for optimal performance.",
         button: "Refresh Firefox…",
         awaitCallback() {
-          return BrowserTestUtils.promiseAlertDialog(
-            "cancel",
-            "chrome://global/content/resetProfile.xul"
-          );
+          return promiseAlertDialog("cancel", [
+            "chrome://global/content/resetProfile.xhtml",
+            "chrome://global/content/resetProfile.xul",
+          ]);
         },
       });
     });
@@ -55,10 +55,10 @@ add_task(async function clear_treatment() {
         title: "Clear Firefox’s cache, cookies, history and more.",
         button: "Choose What to Clear…",
         awaitCallback() {
-          return BrowserTestUtils.promiseAlertDialog(
-            "cancel",
-            "chrome://browser/content/sanitize.xul"
-          );
+          return promiseAlertDialog("cancel", [
+            "chrome://browser/content/sanitize.xhtml",
+            "chrome://browser/content/sanitize.xul",
+          ]);
         },
       });
     });
@@ -220,10 +220,10 @@ add_task(async function survey_treatmentPicked() {
       await awaitTip("clear");
       await Promise.all([
         pickTip(),
-        BrowserTestUtils.promiseAlertDialog(
-          "cancel",
-          "chrome://browser/content/sanitize.xul"
-        ),
+        promiseAlertDialog("cancel", [
+          "chrome://browser/content/sanitize.xhtml",
+          "chrome://browser/content/sanitize.xul",
+        ]),
       ]);
       let tab = await tabPromise;
       Assert.equal(

--- a/tests/tests/browser/browser_updateRefresh_treatment.js
+++ b/tests/tests/browser/browser_updateRefresh_treatment.js
@@ -41,10 +41,10 @@ add_task(async function test() {
           "Firefox is up to date. Trying to fix a problem? Restore default settings and remove old add-ons for optimal performance.",
         button: "Refresh Firefox…",
         awaitCallback() {
-          return BrowserTestUtils.promiseAlertDialog(
-            "cancel",
-            "chrome://global/content/resetProfile.xul"
-          );
+          return promiseAlertDialog("cancel", [
+            "chrome://global/content/resetProfile.xhtml",
+            "chrome://global/content/resetProfile.xul",
+          ]);
         },
       });
     });

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -25,7 +25,7 @@ const { WebExtensionPolicy } = Cu.getGlobalForObject(
 );
 
 // The path of the add-on file relative to `getTestFilePath`.
-const ADDON_PATH = "urlbar_interventions-1.0a1.zip";
+const ADDON_PATH = "urlbar_interventions-1.0a3.zip";
 
 // Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
 // the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.
@@ -655,4 +655,38 @@ async function getExtensionStorage() {
 async function forceSurvey(value) {
   let conn = await getExtensionStorage();
   await conn.set({ surveyURL: "http://example.com/", forceSurvey: value });
+}
+
+/**
+ * Copied from BrowserTestUtils.jsm, but lets you listen for any one of multiple
+ * dialog URIs instead of only one.
+ */
+async function promiseAlertDialogOpen(buttonAction, uris, func) {
+  let win = await BrowserTestUtils.domWindowOpened(null, async win => {
+    // The test listens for the "load" event which guarantees that the alert
+    // class has already been added (it is added when "DOMContentLoaded" is
+    // fired).
+    await BrowserTestUtils.waitForEvent(win, "load");
+
+    return uris.includes(win.document.documentURI);
+  });
+
+  if (func) {
+    await func(win);
+    return win;
+  }
+
+  let dialog = win.document.querySelector("dialog");
+  dialog.getButton(buttonAction).click();
+
+  return win;
+}
+
+/**
+ * Copied from BrowserTestUtils.jsm, but lets you listen for any one of multiple
+ * dialog URIs instead of only one.
+ */
+async function promiseAlertDialog(buttonAction, uris, func) {
+  let win = await promiseAlertDialogOpen(buttonAction, uris, func);
+  return BrowserTestUtils.windowClosed(win);
 }


### PR DESCRIPTION
Please see bug 1604387. This patch fixes the first problem by
matching on whole words only for the first word in the query. For
subsequent words, it matches on prefixes. Prefix matching is done
the same way as whole word matching, by edit distance. So words
in the query can still contain typos while still matching. I
precompute all possible prefixes so that query matching is still
efficient (lookup in a map in constant time).

This fixes the second problem by making "firefox" and "mozilla"
stop words. i.e., the user can type them and they won't match
anything, but they also won't prevent matches.

I think this works pretty well.

Other changes:

* Bump the version number.
* resetProfile.xul and sanitize.xul were recently changed to
  xhtml, so I modified the test to account for that, keeping in
  mind that this experiment still targets 72.