### PR TITLE
Bug 1604387 - Improve QueryScorer.

### DIFF
--- a/src/QueryScorer.js
+++ b/src/QueryScorer.js
@@ -5,43 +5,49 @@
 "use strict";
 
 /**
- * This class scores a query string against sets of keywords.  To refer to a
- * single set of keywords, we borrow the term "document" from search engine
+ * This class scores a query string against sets of phrases.  To refer to a
+ * single set of phrases, we borrow the term "document" from search engine
  * terminology.  To use this class, first add your documents with `addDocument`,
  * and then call `score` with a query string.  `score` returns a sorted array of
  * document-score pairs.
  *
- * The scoring method is simple and is based on Levenshtein edit distance.
- * Therefore, lower scores indicate a better match than higher scores.  In
- * summary, we compute the edit distances between the query words and the words
- * in each document that best match them.  If any of these distances is larger
- * than some threshold -- defined by `distanceThreshold` -- then the document
- * does not match the query, and we assign it a score of Infinity.  The score
- * for a document is the sum of these distances.
- *
- * For example, if the query is a single word, then the distance between it and
- * a given document is the minimum distance between it and all words in the
- * document.  If the document contains the word exactly, then the distance is
- * zero.  If the query is two words, then the distance between it and the
- * document is the sum of the minimum distances between each query word and all
- * words in the document.  For details, see `score`.
+ * The scoring method is fairly simple and is based on Levenshtein edit
+ * distance.  Therefore, lower scores indicate a better match than higher
+ * scores.  In summary, a query matches a phrase if the query starts with the
+ * phrase.  So a query "firefox update foo bar" matches the phrase "firefox
+ * update" for example.  A query matches a document if it matches any phrase in
+ * the document.  The query and phrases are compared word for word, and we allow
+ * fuzzy matching by computing the Levenshtein edit distance in each comparison.
+ * The amount of fuzziness allowed is controlled with `distanceThreshold`.  If
+ * the distance in a comparison is greater than this threshold, then the phrase
+ * does not match the query.  The final score for a document is the minimum edit
+ * distance between its phrases and the query.
  *
  * As mentioned, `score` returns a sorted array of document-score pairs.  It's
  * up to you to filter the array to exclude scores above a certain threshold, or
  * to take the top scorer, etc.
  */
 class QueryScorer {
-  constructor(distanceThreshold = 1) {
+  /**
+   * @param {number} distanceThreshold
+   *   Edit distances no larger than this value are considered matches.
+   * @param {Map} variations
+   *   For convenience, the scorer can augment documents by replacing certain
+   *   words with other words and phrases. This mechanism is called variations.
+   *   This keys of this map are words that should be replaced, and the values
+   *   are the replacement words or phrases.  For example, if you add a document
+   *   whose only phrase is "firefox update", normally the scorer will register
+   *   only this single phrase for the document.  However, if you pass the value
+   *   `new Map(["firefox", ["fire fox", "fox fire", "foxfire"]])` for this
+   *   parameter, it will register 4 total phrases for the document: "fire fox
+   *   update", "fox fire update", "foxfire update", and the original "firefox
+   *   update".
+   */
+  constructor({ distanceThreshold = 1, variations = new Map() } = {}) {
     this._distanceThreshold = distanceThreshold;
-    this._documentsByWord = new Map();
-  }
-
-  get distanceThreshold() {
-    return this._distanceThreshold;
-  }
-
-  set distanceThreshold(value) {
-    this._distanceThreshold = value;
+    this._variations = variations;
+    this._documents = new Set();
+    this._rootNode = new Node();
   }
 
   /**
@@ -51,15 +57,37 @@ class QueryScorer {
    *   The document.
    * @param {string} doc.id
    *   The document's ID.
-   * @param {array} doc.words
-   *   The set of words in the document.
+   * @param {array} doc.phrases
+   *   The set of phrases in the document.  Each phrase should be a string.
    */
   addDocument(doc) {
-    doc.words = doc.words.map(word => word.toLocaleLowerCase());
-    for (let word of doc.words) {
-      let docs = this._documentsByWord.get(word) || new Set();
-      docs.add(doc);
-      this._documentsByWord.set(word, docs);
+    this._documents.add(doc);
+
+    for (let phraseStr of doc.phrases) {
+      // Split the phrase and lowercase the words.
+      let phrase = phraseStr
+        .trim()
+        .split(/\s+/)
+        .map(word => word.toLocaleLowerCase());
+
+      // Build a phrase list that contains the original phrase plus its
+      // variations, if any.
+      let phrases = [phrase];
+      for (let [triggerWord, variations] of this._variations) {
+        let index = phrase.indexOf(triggerWord);
+        if (index >= 0) {
+          for (let variation of variations) {
+            let variationPhrase = Array.from(phrase);
+            variationPhrase.splice(index, 1, ...variation.split(/\s+/));
+            phrases.push(variationPhrase);
+          }
+        }
+      }
+
+      // Finally, add the phrases to the phrase tree.
+      for (let phrase of phrases) {
+        this._buildPhraseTree(this._rootNode, doc, phrase, 0);
+      }
     }
   }
 
@@ -74,47 +102,134 @@ class QueryScorer {
    *   ordered by score from low to high.  Scores represent edit distance, so
    *   lower scores are better.
    */
-  score(searchString) {
-    // For each word in the query string:
-    //
-    // 1. Get its edit distance from all words in all documents.  While we're
-    //    doing that, keep track of the word's minimum distance per document.
-    // 2. For each document, add the minimum distance computed in the previous
-    //    step to a running sum.  This sum is the document's distance score for
-    //    the query string.
-
-    let searchWords = searchString
+  score(queryString) {
+    let queryWords = queryString
       .trim()
       .split(/\s+/)
       .map(word => word.toLocaleLowerCase());
-    let sumByDoc = new Map();
-    for (let searchWord of searchWords) {
-      let minDistanceByDoc = new Map();
-      for (let [docWord, docs] of this._documentsByWord) {
-        let distance = this._levenshtein(searchWord, docWord);
-        if (distance > this.distanceThreshold) {
-          distance = Infinity;
-        }
-        for (let doc of docs) {
-          minDistanceByDoc.set(
-            doc,
-            Math.min(
-              distance,
-              minDistanceByDoc.has(doc) ? minDistanceByDoc.get(doc) : Infinity
-            )
-          );
-        }
-      }
-      for (let [doc, min] of minDistanceByDoc) {
-        sumByDoc.set(doc, min + (sumByDoc.get(doc) || 0));
-      }
-    }
+    let minDistanceByDoc = this._traverse({ queryWords });
     let results = [];
-    for (let [doc, sum] of sumByDoc) {
-      results.push({ document: doc, score: sum });
+    for (let doc of this._documents) {
+      let distance = minDistanceByDoc.get(doc);
+      results.push({
+        document: doc,
+        score: distance === undefined ? Infinity : distance,
+      });
     }
     results.sort((a, b) => a.score - b.score);
     return results;
+  }
+
+  /**
+   * Builds the phrase tree based on the current documents.
+   *
+   * The phrase tree lets us efficiently match queries against phrases.  Each
+   * path through the tree starting from the root and ending at a leaf
+   * represents a complete phrase in a document (or more than one document, if
+   * the same phrase is present in multiple documents).  Each node in the path
+   * represents a word in the phrase.  To match a query, we start at the root,
+   * and in the root we look up the query's first word.  If the word matches the
+   * first word of any phrase, then the root will have a child node representing
+   * that word, and we move on to the child node.  Then we look up the query's
+   * second word in the child node, and so on, until either a lookup fails or we
+   * reach a leaf node.
+   *
+   * @param {Node} node
+   *   The current node being visited.
+   * @param {object} doc
+   *   The document whose phrases are being added to the tree.
+   * @param {array} phrase
+   *   The phrase to add to the tree.
+   * @param {number} wordIndex
+   *   The index in the phrase of the current word.
+   */
+  _buildPhraseTree(node, doc, phrase, wordIndex) {
+    if (phrase.length == wordIndex) {
+      // We're done with this phrase.
+      return;
+    }
+
+    let word = phrase[wordIndex].toLocaleLowerCase();
+    let child = node.childrenByWord.get(word);
+    if (!child) {
+      child = new Node(word);
+      node.childrenByWord.set(word, child);
+    }
+    child.documents.add(doc);
+
+    // Recurse with the next word in the phrase.
+    this._buildPhraseTree(child, doc, phrase, wordIndex + 1);
+  }
+
+  /**
+   * Traverses a path in the phrase tree in order to score a query.  See
+   * `_buildPhraseTree` for a description of how this works.
+   *
+   * @param {array} queryWords
+   *   The query being scored, split into words.
+   * @param {Node} node
+   *   The node currently being visited.
+   * @param {Map} minDistanceByDoc
+   *   Keeps track of the minimum edit distance for each document as the
+   *   traversal continues.
+   * @param {number} queryWordsIndex
+   *   The current index in the query words array.
+   * @param {number} phraseDistance
+   *   The total edit distance between the query and the path in the tree that's
+   *   been traversed so far.
+   * @return {Map} minDistanceByDoc
+   */
+  _traverse({
+    queryWords,
+    node = this._rootNode,
+    minDistanceByDoc = new Map(),
+    queryWordsIndex = 0,
+    phraseDistance = 0,
+  } = {}) {
+    if (!node.childrenByWord.size) {
+      // We reached a leaf node.  The query has matched a phrase.  If the query
+      // and the phrase have the same number of words, then queryWordsIndex ==
+      // queryWords.length also.  Otherwise the query contains more words than
+      // the phrase.  We still count that as a match.
+      for (let doc of node.documents) {
+        minDistanceByDoc.set(
+          doc,
+          Math.min(
+            phraseDistance,
+            minDistanceByDoc.has(doc) ? minDistanceByDoc.get(doc) : Infinity
+          )
+        );
+      }
+      return minDistanceByDoc;
+    }
+
+    if (queryWordsIndex == queryWords.length) {
+      // We exhausted all the words in the query but have not reached a leaf
+      // node.  No match; the query has matched a phrase(s) up to this point,
+      // but it doesn't have enough words.
+      return minDistanceByDoc;
+    }
+
+    // Compare each word in the node to the current query word.
+    let queryWord = queryWords[queryWordsIndex];
+    for (let [childWord, child] of node.childrenByWord) {
+      let distance = this._levenshtein(queryWord, childWord);
+      if (distance <= this._distanceThreshold) {
+        // The word represented by this child node matches the current query
+        // word.  Recurse into the child node.
+        this._traverse({
+          node: child,
+          queryWords,
+          queryWordsIndex: queryWordsIndex + 1,
+          phraseDistance: phraseDistance + distance,
+          minDistanceByDoc,
+        });
+      }
+      // Else, the path that continues at the child node can't possibly match
+      // the query, so don't recurse into it.
+    }
+
+    return minDistanceByDoc;
   }
 
   /**
@@ -183,5 +298,16 @@ class QueryScorer {
     c0 = p1[l2];
 
     return c0;
+  }
+}
+
+/**
+ * A node in the scorer's phrase tree.
+ */
+class Node {
+  constructor(word) {
+    this.word = word;
+    this.documents = new Set();
+    this.childrenByWord = new Map();
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -35,63 +35,76 @@ const TIPS = {
   UPDATE_WEB: "update_web",
 };
 
-// Keywords for each tip type.
-const KEYWORDS = {
-  update: [
-    "2019",
-    "browser",
-    "download",
-    "fire",
-    "firefox",
-    "fox",
-    "free",
-    "get",
-    "install",
-    "installer",
-    "latest",
-    "mac",
-    "mozilla",
-    "new",
-    "newest",
-    "quantum",
-    "update",
-    "updates",
-    "version",
-    "windows",
-    "www.firefox.com",
-  ],
+// The search "documents" corresponding to each tip type.
+const DOCUMENTS = {
   clear: [
-    "cache",
-    "clear",
-    "cookie",
-    "cookies",
-    "delete",
-    "firefox",
-    "history",
-    "load",
-    "loading",
-    "loads",
-    "location",
-    "page",
+    "cache firefox",
+    "clear cache firefox",
+    "clear cache in firefox",
+    "clear cookies firefox",
+    "clear firefox cache",
+    "clear history firefox",
+    "cookies firefox",
+    "delete cookies firefox",
+    "delete history firefox",
+    "firefox cache",
+    "firefox clear cache",
+    "firefox clear cookies",
+    "firefox clear history",
+    "firefox cookie",
+    "firefox cookies",
+    "firefox delete cookies",
+    "firefox delete history",
+    "firefox history",
+    "firefox not loading pages",
+    "history firefox",
+    "how to clear cache",
+    "how to clear history",
   ],
   refresh: [
-    "crash",
-    "crashes",
-    "crashing",
-    "firefox",
-    "keep",
-    "keeps",
-    "not",
-    "refresh",
-    "reset",
-    "respond",
-    "responding",
-    "responds",
-    "slow",
-    "slows",
-    "work",
-    "working",
-    "works",
+    "firefox crashing",
+    "firefox keeps crashing",
+    "firefox not responding",
+    "firefox not working",
+    "firefox refresh",
+    "firefox slow",
+    "how to reset firefox",
+    "refresh firefox",
+    "reset firefox",
+  ],
+  update: [
+    "download firefox",
+    "download mozilla",
+    "firefox browser",
+    "firefox download",
+    "firefox for mac",
+    "firefox for windows",
+    "firefox free download",
+    "firefox install",
+    "firefox installer",
+    "firefox latest version",
+    "firefox mac",
+    "firefox quantum",
+    "firefox update",
+    "firefox version",
+    "firefox windows",
+    "get firefox",
+    "how to update firefox",
+    "install firefox",
+    "mozilla download",
+    "mozilla firefox 2019",
+    "mozilla firefox 2020",
+    "mozilla firefox download",
+    "mozilla firefox for mac",
+    "mozilla firefox for windows",
+    "mozilla firefox free download",
+    "mozilla firefox mac",
+    "mozilla firefox update",
+    "mozilla firefox windows",
+    "mozilla update",
+    "update firefox",
+    "update mozilla",
+    "www.firefox.com",
   ],
 };
 
@@ -115,7 +128,12 @@ let studyBranch;
 let currentTip = TIPS.NONE;
 
 // Object used to match the user's queries to tips.
-let queryScorer = new QueryScorer();
+let queryScorer = new QueryScorer({
+  variations: new Map([
+    // Recognize "fire fox", "fox fire", and "foxfire" as "firefox".
+    ["firefox", ["fire fox", "fox fire", "foxfire"]],
+  ]),
+});
 
 // Tips shown in the current engagement (TIPS values).
 let tipsShownInCurrentEngagement = new Set();
@@ -475,8 +493,8 @@ async function enroll() {
   });
 
   // Initialize the query scorer.
-  for (let docID in KEYWORDS) {
-    queryScorer.addDocument({ id: docID, words: KEYWORDS[docID] });
+  for (let [id, phrases] of Object.entries(DOCUMENTS)) {
+    queryScorer.addDocument({ id, phrases });
   }
 
   // Trigger a browser update check.  (This won't actually check if updates are

--- a/src/background.js
+++ b/src/background.js
@@ -132,6 +132,10 @@ let queryScorer = new QueryScorer({
   variations: new Map([
     // Recognize "fire fox", "fox fire", and "foxfire" as "firefox".
     ["firefox", ["fire fox", "fox fire", "foxfire"]],
+    // Recognize "mozila" as "mozilla".  This will catch common mispellings
+    // "mozila", "mozzila", and "mozzilla" (among others) due to the edit
+    // distance threshold of 1.
+    ["mozilla", ["mozila"]],
   ]),
 });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Urlbar Interventions",
-  "version": "1.0a2",
+  "version": "1.0a3",
   "description": "Shows relevant tips in the urlbar view when you type certain search terms.",
   "applications": {
     "gecko": {

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -5,7 +5,7 @@
 [DEFAULT]
 support-files =
   head.js
-  ../urlbar_interventions-1.0a1.zip
+  ../urlbar_interventions-1.0a3.zip
   ../../../../toolkit/mozapps/update/tests/data/shared.js
   ../../../../toolkit/mozapps/update/tests/data/sharedUpdateXML.js
   ../../../../toolkit/mozapps/update/tests/browser/app_update.sjs

--- a/tests/tests/browser/browser_test.js
+++ b/tests/tests/browser/browser_test.js
@@ -15,16 +15,16 @@ add_task(async function refresh_treatment() {
       // Pick the tip, which should open the refresh dialog.  Click its cancel
       // button.
       await doTreatmentTest({
-        searchString: "refresh",
+        searchString: SEARCH_STRINGS.REFRESH,
         tip: TIPS.REFRESH,
         title:
           "Restore default settings and remove old add-ons for optimal performance.",
         button: "Refresh Firefox…",
         awaitCallback() {
-          return BrowserTestUtils.promiseAlertDialog(
-            "cancel",
-            "chrome://global/content/resetProfile.xul"
-          );
+          return promiseAlertDialog("cancel", [
+            "chrome://global/content/resetProfile.xhtml",
+            "chrome://global/content/resetProfile.xul",
+          ]);
         },
       });
     });
@@ -36,7 +36,7 @@ add_task(async function refresh_control() {
   await withStudy({ branch: BRANCHES.CONTROL }, async () => {
     await withAddon(async () => {
       await doControlTest({
-        searchString: "refresh",
+        searchString: SEARCH_STRINGS.REFRESH,
         tip: TIPS.REFRESH,
       });
     });
@@ -50,15 +50,15 @@ add_task(async function clear_treatment() {
       // Pick the tip, which should open the refresh dialog.  Click its cancel
       // button.
       await doTreatmentTest({
-        searchString: "clear",
+        searchString: SEARCH_STRINGS.CLEAR,
         tip: TIPS.CLEAR,
         title: "Clear Firefox’s cache, cookies, history and more.",
         button: "Choose What to Clear…",
         awaitCallback() {
-          return BrowserTestUtils.promiseAlertDialog(
-            "cancel",
-            "chrome://browser/content/sanitize.xul"
-          );
+          return promiseAlertDialog("cancel", [
+            "chrome://browser/content/sanitize.xhtml",
+            "chrome://browser/content/sanitize.xul",
+          ]);
         },
       });
     });
@@ -70,7 +70,7 @@ add_task(async function clear_control() {
   await withStudy({ branch: BRANCHES.CONTROL }, async () => {
     await withAddon(async () => {
       await doControlTest({
-        searchString: "clear",
+        searchString: SEARCH_STRINGS.CLEAR,
         tip: TIPS.CLEAR,
       });
     });
@@ -94,14 +94,14 @@ add_task(async function clear_treatment_private() {
 
       // First, make sure the extension works in PBM by triggering a non-clear
       // tip.
-      let result = (await awaitTip("refresh", win))[0];
+      let result = (await awaitTip(SEARCH_STRINGS.REFRESH, win))[0];
       Assert.strictEqual(result.payload.type, TIPS.REFRESH);
 
       // Blur the urlbar so that the engagement is ended.
       await UrlbarTestUtils.promisePopupClose(win, () => win.gURLBar.blur());
 
       // Now do a search that would trigger the clear tip.
-      await awaitNoTip("clear", win);
+      await awaitNoTip(SEARCH_STRINGS.CLEAR, win);
 
       // Blur the urlbar so that the engagement is ended.
       await UrlbarTestUtils.promisePopupClose(win, () => win.gURLBar.blur());
@@ -217,13 +217,13 @@ add_task(async function survey_treatmentPicked() {
     await withAddon(async () => {
       await forceSurvey(FORCE_SURVEY_ENABLE);
       let tabPromise = BrowserTestUtils.waitForNewTab(gBrowser);
-      await awaitTip("clear");
+      await awaitTip(SEARCH_STRINGS.CLEAR);
       await Promise.all([
         pickTip(),
-        BrowserTestUtils.promiseAlertDialog(
-          "cancel",
-          "chrome://browser/content/sanitize.xul"
-        ),
+        promiseAlertDialog("cancel", [
+          "chrome://browser/content/sanitize.xhtml",
+          "chrome://browser/content/sanitize.xul",
+        ]),
       ]);
       let tab = await tabPromise;
       Assert.equal(
@@ -241,7 +241,7 @@ add_task(async function survey_treatmentIgnored() {
     await withAddon(async () => {
       await forceSurvey(FORCE_SURVEY_ENABLE);
       let tabPromise = BrowserTestUtils.waitForNewTab(gBrowser);
-      await awaitTip("clear");
+      await awaitTip(SEARCH_STRINGS.CLEAR);
       await UrlbarTestUtils.promisePopupClose(window, () => gURLBar.blur());
       let tab = await tabPromise;
       Assert.equal(
@@ -259,7 +259,7 @@ add_task(async function survey_control() {
     await withAddon(async () => {
       await forceSurvey(FORCE_SURVEY_ENABLE);
       let tabPromise = BrowserTestUtils.waitForNewTab(gBrowser);
-      await awaitNoTip("clear");
+      await awaitNoTip(SEARCH_STRINGS.CLEAR);
       await UrlbarTestUtils.promisePopupClose(window, () => gURLBar.blur());
       let tab = await tabPromise;
       Assert.equal(
@@ -277,7 +277,7 @@ add_task(async function survey_twice() {
     await withAddon(async () => {
       await forceSurvey(FORCE_SURVEY_ENABLE);
       let tabPromise = BrowserTestUtils.waitForNewTab(gBrowser);
-      await awaitTip("clear");
+      await awaitTip(SEARCH_STRINGS.CLEAR);
       await UrlbarTestUtils.promisePopupClose(window, () => gURLBar.blur());
       let tab = await tabPromise;
       Assert.equal(
@@ -288,7 +288,7 @@ add_task(async function survey_twice() {
 
       let count = gBrowser.tabs.length;
       Assert.equal(typeof count, "number", "Sanity check");
-      await awaitTip("clear");
+      await awaitTip(SEARCH_STRINGS.CLEAR);
       await UrlbarTestUtils.promisePopupClose(window, () => gURLBar.blur());
       // eslint-disable-next-line mozilla/no-arbitrary-setTimeout
       await new Promise(r => setTimeout(r, 1000));
@@ -304,7 +304,7 @@ add_task(async function unenrollAfterInstall() {
         awaitAddonMessage("unenrolled"),
         AddonStudies.markAsEnded(study),
       ]);
-      await awaitNoTip("refresh");
+      await awaitNoTip(SEARCH_STRINGS.REFRESH);
     });
   });
 });
@@ -313,7 +313,7 @@ add_task(async function unenrollBeforeInstall() {
   await withStudy({ branch: BRANCHES.TREATMENT }, async study => {
     await AddonStudies.markAsEnded(study);
     await withAddon(async () => {
-      await awaitNoTip("refresh");
+      await awaitNoTip(SEARCH_STRINGS.REFRESH);
     });
   });
 });
@@ -321,7 +321,7 @@ add_task(async function unenrollBeforeInstall() {
 add_task(async function noBranch() {
   await withStudy({}, async () => {
     await withAddon(async () => {
-      await awaitNoTip("refresh");
+      await awaitNoTip(SEARCH_STRINGS.REFRESH);
     });
   });
 });
@@ -329,7 +329,7 @@ add_task(async function noBranch() {
 add_task(async function unrecognizedBranch() {
   await withStudy({ branch: "bogus" }, async () => {
     await withAddon(async () => {
-      await awaitNoTip("refresh");
+      await awaitNoTip(SEARCH_STRINGS.REFRESH);
     });
   });
 });

--- a/tests/tests/browser/browser_updateAsk_control.js
+++ b/tests/tests/browser/browser_updateAsk_control.js
@@ -43,7 +43,7 @@ add_task(async function test() {
       await processUpdateSteps(preSteps);
 
       await doControlTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_ASK,
       });
     });

--- a/tests/tests/browser/browser_updateAsk_treatment.js
+++ b/tests/tests/browser/browser_updateAsk_treatment.js
@@ -59,7 +59,7 @@ add_task(async function test() {
       // Pick the tip and continue with the mock update, which should attempt to
       // restart the browser.
       await doTreatmentTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_ASK,
         title: "A new version of Firefox is available.",
         button: "Install and Restart to Update",

--- a/tests/tests/browser/browser_updateRefresh_control.js
+++ b/tests/tests/browser/browser_updateRefresh_control.js
@@ -33,7 +33,7 @@ add_task(async function test() {
       await processUpdateSteps(preSteps);
 
       await doControlTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_REFRESH,
       });
     });

--- a/tests/tests/browser/browser_updateRefresh_treatment.js
+++ b/tests/tests/browser/browser_updateRefresh_treatment.js
@@ -35,16 +35,16 @@ add_task(async function test() {
       // Picking the tip should open the refresh dialog.  Click its cancel
       // button.
       await doTreatmentTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_REFRESH,
         title:
           "Firefox is up to date. Trying to fix a problem? Restore default settings and remove old add-ons for optimal performance.",
         button: "Refresh Firefox…",
         awaitCallback() {
-          return BrowserTestUtils.promiseAlertDialog(
-            "cancel",
-            "chrome://global/content/resetProfile.xul"
-          );
+          return promiseAlertDialog("cancel", [
+            "chrome://global/content/resetProfile.xhtml",
+            "chrome://global/content/resetProfile.xul",
+          ]);
         },
       });
     });

--- a/tests/tests/browser/browser_updateRestart_control.js
+++ b/tests/tests/browser/browser_updateRestart_control.js
@@ -38,7 +38,7 @@ add_task(async function test() {
       await processUpdateSteps(preSteps);
 
       await doControlTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_RESTART,
       });
     });

--- a/tests/tests/browser/browser_updateRestart_treatment.js
+++ b/tests/tests/browser/browser_updateRestart_treatment.js
@@ -39,7 +39,7 @@ add_task(async function test() {
 
       // Picking the tip should attempt to restart the browser.
       await doTreatmentTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_RESTART,
         title: "The latest Firefox is downloaded and ready to install.",
         button: "Restart to Update",

--- a/tests/tests/browser/browser_updateWeb_control.js
+++ b/tests/tests/browser/browser_updateWeb_control.js
@@ -32,7 +32,7 @@ add_task(async function test() {
       await processUpdateSteps(preSteps);
 
       await doControlTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_WEB,
       });
     });

--- a/tests/tests/browser/browser_updateWeb_treatment.js
+++ b/tests/tests/browser/browser_updateWeb_treatment.js
@@ -33,7 +33,7 @@ add_task(async function test() {
 
       // Picking the tip should open the download page in a new tab.
       let downloadTab = await doTreatmentTest({
-        searchString: "update",
+        searchString: SEARCH_STRINGS.UPDATE,
         tip: TIPS.UPDATE_WEB,
         title: "Get the latest Firefox browser.",
         button: "Download Now",


### PR DESCRIPTION
This rewrites QueryScorer to implement fuzzy phrase matching.
Hopefully the code comments explain things well enough. In
summary, documents are now collections of phrases instead of
words. A query matches a phrase if the query starts with the
phrase. So a query "firefox update foo bar" matches the phrase
"firefox update" for example. A query matches a document if it
matches any phrase in the document.

In order to do matching effeciently, I implemented a tree
structure called a "phrase tree". The comment above
_buildPhraseTree describes it.

I also implemented a convenience called "variations" that
automatically augments documents so that certain words are
replaced with other words or phrases. I use this to
recognize "fire fox", "fox fire", and "foxfire" in addition
to "firefox". This system isn't strictly necessary because we
could simply manually list all phrases with these replacements,
but that would require a lot of copy and pasting with slight
differences.

The phrases in background.js are taken from Verdi's doc with some
slight changes:

* Removed phrases that only consist of "firefox" or "mozilla".
  After talking with mconnor, Verdi said they shouldn't trigger
  interventions.
* Removed phrases that start with other phrases. For example,
  "download firefox for mac" starts with "download firefox", so
  I don't include it ("download firefox for mac"). QueryScorer
  matches any query that starts with a registered phrase, so in
  this case any query that starts with "download firefox".
* I added "firefox history" because it wasn't on the list but
  "history firefox" was.

Other changes in this patch:

* Bump the version number.
* resetProfile.xul and sanitize.xul were recently changed to
  xhtml, so I modified the test to account for that, keeping in
  mind that this experiment still targets 72.