### PR TITLE
Bug 1604692 - Don't open the survey page once the user has started it.

### DIFF
--- a/src/content/survey.js
+++ b/src/content/survey.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* global browser */
+
+// The initial survey page shows a Next button that the user must click to start
+// the survey.  The button is a submit button in a form, and we can add a
+// listener on the window to listen for submit.
+addEventListener(
+  "submit",
+  async () => {
+    // The background script removes its listener the first time it receives
+    // this message.  If we try to send again, sendMessage throws, and it shows
+    // up in the browser console.  It doesn't actually matter in practice
+    // because the add-on opens the survey page no more than once per session,
+    // but it seems like good practice not to assume that.
+    try {
+      await browser.runtime.sendMessage("submit");
+    } catch (ex) {}
+  },
+  { once: true }
+);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Urlbar Interventions",
-  "version": "1.0a3",
+  "version": "1.0a4",
   "description": "Shows relevant tips in the urlbar view when you type certain search terms.",
   "applications": {
     "gecko": {
@@ -16,6 +16,7 @@
     }
   },
   "permissions": [
+    "https://qsurvey.mozilla.com/s3/Search-Interventions",
     "normandyAddonStudy",
     "storage",
     "telemetry",

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -5,7 +5,7 @@
 [DEFAULT]
 support-files =
   head.js
-  ../urlbar_interventions-1.0a3.zip
+  ../urlbar_interventions-1.0a4.zip
   ../../../../toolkit/mozapps/update/tests/data/shared.js
   ../../../../toolkit/mozapps/update/tests/data/sharedUpdateXML.js
   ../../../../toolkit/mozapps/update/tests/browser/app_update.sjs

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -25,7 +25,7 @@ const { WebExtensionPolicy } = Cu.getGlobalForObject(
 );
 
 // The path of the add-on file relative to `getTestFilePath`.
-const ADDON_PATH = "urlbar_interventions-1.0a3.zip";
+const ADDON_PATH = "urlbar_interventions-1.0a4.zip";
 
 // Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
 // the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.


### PR DESCRIPTION
We can use a content script in the survey page and listen for the
submit event. The code comments in survey.js explain a little
more. For reference, the survey URL is
https://qsurvey.mozilla.com/s3/Search-Interventions

This also bumps the add-on version since this is the first change
since I last asked the add-on to be signed (today).