### PR TITLE
Bug 1605351 - Don't remove all storage when showing the survey on startup; other storage and survey-on-startup changes.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Urlbar Interventions",
-  "version": "1.0a4",
+  "version": "1.0a5",
   "description": "Shows relevant tips in the urlbar view when you type certain search terms.",
   "applications": {
     "gecko": {

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -5,7 +5,7 @@
 [DEFAULT]
 support-files =
   head.js
-  ../urlbar_interventions-1.0a4.zip
+  ../urlbar_interventions-1.0a5.zip
   ../../../../toolkit/mozapps/update/tests/data/shared.js
   ../../../../toolkit/mozapps/update/tests/data/sharedUpdateXML.js
   ../../../../toolkit/mozapps/update/tests/browser/app_update.sjs

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -25,7 +25,7 @@ const { WebExtensionPolicy } = Cu.getGlobalForObject(
 );
 
 // The path of the add-on file relative to `getTestFilePath`.
-const ADDON_PATH = "urlbar_interventions-1.0a4.zip";
+const ADDON_PATH = "urlbar_interventions-1.0a5.zip";
 
 // Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
 // the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.


### PR DESCRIPTION
The reason this bug happens is that I clear the entire storage
after opening the survey on startup, so the `surveyOpenedCount`
is forgotten. I should only remove the flag that indicates we
need to open the survey on startup.

This bug plus some prior conversation with QA made me realize
that the add-on doesn't handle the survey for the refresh and
update_refresh tips very well. It treats those tips as two of the
cases where we should open the survey on startup, since
refreshing the browser restarts it. But of course once the
browser restarts due to refresh, all add-ons are uninstalled,
including this one, so it can't possibly open the survey then. So
this patch opens the survey immediately for these two tips. The
user can at least see the survey in these cases if they cancel
the refresh dialog.

Other changes:

* Rename `storage.surveyPickedTip` to `surveyToOpenOnStartup` for
  clarity.
* Simplify some other uses of `browser.storage.local.set`. `set`
  doesn't actually set the whole storage to the object you pass
  in. Instead it merges the object into the storage. So there's
  no need to first get the storage, update a single property, and
  then set it. You can just set it.
* Bump the version to 1.0a5 since this is the first change since
  the add-on was last signed.